### PR TITLE
Albums/artists inf scroll to defer load

### DIFF
--- a/src/pages/PageAlbums.vue
+++ b/src/pages/PageAlbums.vue
@@ -44,6 +44,8 @@ const albumsData = {
     vm.limit = 50
     vm.offset = 0
     vm.append_albums(response.data)
+
+    vm.timer = setTimeout(vm.bg_load_next, 5000)
   }
 }
 
@@ -58,7 +60,8 @@ export default {
       album_els: [],
       limit: 1,
       offset: 0,
-      total: 0
+      total: 0,
+      timer: {}
     }
   },
 
@@ -89,6 +92,14 @@ export default {
         if (this.offset >= this.total) {
           $state.complete()
         }
+      }
+    },
+
+    bg_load_next: function () {
+      clearTimeout(this.timer)
+      if (this.offset < this.total) {
+        this.load_next()
+        this.timer = setTimeout(this.bg_load_next, 5000)
       }
     }
   }

--- a/src/pages/PageArtists.vue
+++ b/src/pages/PageArtists.vue
@@ -44,6 +44,8 @@ const artistsData = {
     vm.limit = 50
     vm.offset = 0
     vm.append_artists(response.data)
+
+    vm.timer = setTimeout(vm.bg_load_next, 5000)
   }
 }
 
@@ -58,7 +60,8 @@ export default {
       artist_els: [],
       limit: 50,
       offset: 0,
-      total: 0
+      total: 0,
+      timer: {}
     }
   },
 
@@ -89,6 +92,14 @@ export default {
         if (this.offset >= this.total) {
           $state.complete()
         }
+      }
+    },
+
+    bg_load_next: function () {
+      clearTimeout(this.timer)
+      if (this.offset < this.total) {
+        this.load_next()
+        this.timer = setTimeout(this.bg_load_next, 5000)
       }
     }
   }

--- a/src/webapi/index.js
+++ b/src/webapi/index.js
@@ -107,6 +107,10 @@ export default {
     return axios.put('/api/outputs/' + outputId, output)
   },
 
+  library_artists_pag (offset, limit) {
+    return axios.get('/api/library/artists?media_kind=music&limit=' + limit + '&offset=' + offset)
+  },
+
   library_artists () {
     return axios.get('/api/library/artists?media_kind=music')
   },
@@ -120,6 +124,10 @@ export default {
       return axios.get('/api/library/artists/' + artistId + '/albums')
     }
     return axios.get('/api/library/albums?media_kind=music')
+  },
+
+  library_albums_pag (offset, limit) {
+    return axios.get('/api/library/albums?limit=' + limit + '&offset=' + offset)
   },
 
   library_album (albumId) {


### PR DESCRIPTION
When loading `albums` or `artists`  (via `/music/artists`) from a large library on mobile devices/netbooks, the initial load is slow for page render.

PR to perform async/infinity scroll loading like the Spotify pages - backend server (0.26.2) already provides looking up via `offset` and `limit`.