### PR TITLE
support 'play next' for albums/artists/tracks

### DIFF
--- a/src/components/ListItemAlbum.vue
+++ b/src/components/ListItemAlbum.vue
@@ -34,6 +34,9 @@
               <a class="card-footer-item has-text-dark" @click="queue_add">
                 <span class="icon"><i class="mdi mdi-playlist-plus mdi-18px"></i></span> <span>Add</span>
               </a>
+              <a class="card-footer-item has-text-dark" @click="queue_add_next">
+                <span class="icon"><i class="mdi mdi-playlist-play mdi-18px"></i></span> <span>Play Next</span>
+              </a>
               <a class="card-footer-item has-text-dark" @click="play">
                 <span class="icon"><i class="mdi mdi-play mdi-18px"></i></span> <span>Play</span>
               </a>
@@ -75,6 +78,13 @@ export default {
       this.show_details_modal = false
       webapi.queue_add(this.album.uri).then(() =>
         this.$store.dispatch('add_notification', { text: 'Album tracks appended to queue', type: 'info', timeout: 2000 })
+      )
+    },
+
+    queue_add_next: function () {
+      this.show_details_modal = false
+      webapi.queue_add_next(this.album.uri).then(() =>
+        this.$store.dispatch('add_notification', { text: 'Album tracks playing next', type: 'info', timeout: 2000 })
       )
     },
 

--- a/src/components/ListItemArtist.vue
+++ b/src/components/ListItemArtist.vue
@@ -76,7 +76,6 @@ export default {
       )
     },
 
-
     queue_add_next: function () {
       this.show_details_modal = false
       webapi.queue_add_next(this.artist.uri).then(() =>

--- a/src/components/ListItemArtist.vue
+++ b/src/components/ListItemArtist.vue
@@ -29,6 +29,9 @@
               <a class="card-footer-item has-text-dark" @click="queue_add">
                 <span class="icon"><i class="mdi mdi-playlist-plus mdi-18px"></i></span> <span>Add</span>
               </a>
+              <a class="card-footer-item has-text-dark" @click="queue_add_next">
+                <span class="icon"><i class="mdi mdi-playlist-play mdi-18px"></i></span> <span>Play Next</span>
+              </a>
               <a class="card-footer-item has-text-dark" @click="play">
                 <span class="icon"><i class="mdi mdi-play mdi-18px"></i></span> <span>Play</span>
               </a>
@@ -70,6 +73,14 @@ export default {
       this.show_details_modal = false
       webapi.queue_add(this.artist.uri).then(() =>
         this.$store.dispatch('add_notification', { text: 'Artist tracks appended to queue', type: 'info', timeout: 2000 })
+      )
+    },
+
+
+    queue_add_next: function () {
+      this.show_details_modal = false
+      webapi.queue_add_next(this.artist.uri).then(() =>
+        this.$store.dispatch('add_notification', { text: 'Artist tracks playing next', type: 'info', timeout: 2000 })
       )
     },
 

--- a/src/components/ListItemTrack.vue
+++ b/src/components/ListItemTrack.vue
@@ -66,6 +66,9 @@
               <a class="card-footer-item has-text-dark" @click="queue_add">
                 <span class="icon"><i class="mdi mdi-playlist-plus mdi-18px"></i></span> <span>Add</span>
               </a>
+              <a class="card-footer-item has-text-dark" @click="queue_add_next">
+                <span class="icon"><i class="mdi mdi-playlist-play mdi-18px"></i></span> <span>Play Next</span>
+              </a>
               <a class="card-footer-item has-text-dark" @click="play_track">
                 <span class="icon"><i class="mdi mdi-play mdi-18px"></i></span> <span>Play</span>
               </a>
@@ -116,6 +119,13 @@ export default {
       this.show_details_modal = false
       webapi.queue_add(this.track.uri).then(() =>
         this.$store.dispatch('add_notification', { text: 'Track appended to queue', type: 'info', timeout: 2000 })
+      )
+    },
+
+    queue_add_next: function () {
+      this.show_details_modal = false
+      webapi.queue_add_next(this.track.uri).then(() =>
+        this.$store.dispatch('add_notification', { text: 'Track playing next', type: 'info', timeout: 2000 })
       )
     },
 

--- a/src/webapi/index.js
+++ b/src/webapi/index.js
@@ -42,11 +42,11 @@ export default {
   },
 
   queue_add (uri) {
-    return axios.post('/api/queue/items/add?next=0&uris=' + uri)
+    return axios.post('/api/queue/items/add?uris=' + uri)
   },
 
   queue_add_next (uri) {
-    return axios.post('/api/queue/items/add?next=1&uris=' + uri)
+    return axios.post('/api/queue/items/addnext?uris=' + uri)
   },
 
   player_status () {

--- a/src/webapi/index.js
+++ b/src/webapi/index.js
@@ -42,7 +42,11 @@ export default {
   },
 
   queue_add (uri) {
-    return axios.post('/api/queue/items/add?uris=' + uri)
+    return axios.post('/api/queue/items/add?next=0&uris=' + uri)
+  },
+
+  queue_add_next (uri) {
+    return axios.post('/api/queue/items/add?next=1&uris=' + uri)
   },
 
   player_status () {


### PR DESCRIPTION
Front end updates for corresponding backend functionality (https://github.com/ejurgensen/forked-daapd/pull/581) to support `play next` for `albums/artists/tracks`